### PR TITLE
Mode 03 implemented and tested, tests updated.

### DIFF
--- a/peripherals/timer/Timer.vhd
+++ b/peripherals/timer/Timer.vhd
@@ -3,27 +3,32 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 entity Timer is
+	generic(
+		prescaler_size : integer := 16;
+		compare_size : integer := 32 
+		);
 	port(
 		clock      : in  std_logic;
 		reset      : in  std_logic;
 		timer_mode : in  unsigned(1 downto 0);
-		prescaler  : in  unsigned(15 downto 0);
-		compare    : in  unsigned(31 downto 0);
+		prescaler  : in  unsigned(prescaler_size-1 downto 0);
+		compare    : in  unsigned(compare_size-1 downto 0);
 		output     : out std_logic;
 		inv_output : out std_logic
 	);
 end entity Timer;
 
 architecture RTL of Timer is
-
-	signal counter        : unsigned(31 downto 0) := (others => '0');
+	constant counter_max	: unsigned(compare_size-1 downto 0) := (others => '1');
+	signal counter        : unsigned(compare_size-1 downto 0) := (others => '0');
 	signal internal_clock : std_logic             := '1';
+	signal internal_counter_direction : std_logic             := '0';
+--	type counter_direction_t is (Up, Down);
 
 begin
 
-	p1 : process(clock) is -- @suppress "Incomplete sensitivity list. Missing signals: internal_clock, prescaler"
-		variable temp_counter : unsigned(16 downto 0) := (others => '0'); -- 17 bits devido ao prescaler ser multiplicado por 2.
-
+	p1 : process(clock) is              -- @suppress "Incomplete sensitivity list. Missing signals: prescaler, internal_clock"
+		variable temp_counter : unsigned(prescaler_size-1 downto 0) := (others => '0'); -- 17 bits devido ao prescaler ser multiplicado por 2.
 	begin
 		if rising_edge(clock) OR falling_edge(clock) then
 			temp_counter := temp_counter + 1;
@@ -35,38 +40,74 @@ begin
 	end process p1;
 
 	p2 : process(internal_clock) is
-		variable internal_output : std_logic := '0';
+		variable internal_output   : std_logic           := '0';
+		variable counter_direction : std_logic := '0';
 	begin
 		if rising_edge(internal_clock) then
 
 			if reset = '1' then
 				internal_output := '0';
 				counter         <= (others => '0');
+				counter_direction := '0';
+				
 			else
 				case timer_mode is
 					when "00" =>        -- one shot mode
 
-						if counter >= compare -1 then
+						if counter >= compare - 1 then
 							internal_output := '1';
 						else
 							internal_output := '0';
-							counter <= counter + 1;
+							counter         <= counter + 1;
 						end if;
 
-					when "01" =>        -- clear on compare mode
+					when "01" =>        -- clear on compare mode, counter is as sawtooth wave
 
-						-- counter reset if reaches its maximum possible value
-						if counter = counter'high -1 then
+						-- the counter reset if reaches its maximum possible value
+						-- the output is has a rectangular waveform like a simple PWM
+						if counter >= counter_max then
 							counter <= (others => '0');
 						else
 							counter <= counter + 1;
 						end if;
 
-						if counter >= compare -1 then
+						if counter >= compare - 1 then
 							internal_output := '1';
 						else
 							internal_output := '0';
 						end if;
+
+					when "10" =>        -- clear on compare mode, counter is a centered triangle wave
+
+						-- the counter change its direction (up or down) when it reaches its maximum possible value
+						-- the output has a rectangular waveform centered to the top value
+						if counter_direction = '0' then
+							if counter >= counter_max then
+								counter_direction := '1';
+							else
+								counter <= counter + 1;
+							end if;
+
+							if counter >= compare - 1 then
+								internal_output := '1';
+							else
+								internal_output := '0';
+							end if;
+
+						else
+							if counter <= 0 then
+								counter_direction := '1';
+							else
+								counter <= counter - 1;
+							end if;
+
+							if counter > compare - 1 then
+								internal_output := '1';
+							else
+								internal_output := '0';
+							end if;
+						end if;
+						internal_counter_direction <= counter_direction;
 
 					when others =>      -- none / error
 						internal_output := '0';

--- a/peripherals/timer/tb_timer_mode_00.do
+++ b/peripherals/timer/tb_timer_mode_00.do
@@ -15,18 +15,19 @@ view wave
 #  -label: nome da forma de onda
 add wave -radix binary -label clock /clock
 add wave -radix binary -label reset /reset
-add wave -radix dec -label timer_mode /timer_mode
-add wave -radix dec -label prescaler /prescaler
-add wave -radix dec -label compare /compare
+add wave -radix binary -label mode /timer_mode
+add wave -radix unsigned -label prescaler /prescaler
+add wave -radix unsigned -label compare /compare
 add wave -radix binary -label output /output
 add wave -radix binary -label inv_output /inv_output
 
 # Mostra sinais internos do processo
-add wave -radix dec -label counter /dut/counter
+add wave -radix unsigned -label counter /dut/counter
 add wave -radix binary -label internal_clock /dut/internal_clock
+add wave -radix binary -label counter_direction /dut/internal_counter_direction
 
 # Simula
-run 300ns
+run 2400ns
 
 wave zoomfull
 write wave testbench_timer_mode_00_wave.ps

--- a/peripherals/timer/tb_timer_mode_00.vhd
+++ b/peripherals/timer/tb_timer_mode_00.vhd
@@ -9,13 +9,20 @@ end entity testbench_timer_mode_00;
 
 architecture stimulus of testbench_timer_mode_00 is
 
+	constant prescaler_size_for_test : integer := 16;
+	constant compare_size_for_test   : integer := 4;
+
 	component Timer
+		generic(
+			prescaler_size : integer := prescaler_size_for_test;
+			compare_size   : integer := compare_size_for_test
+		);
 		port(
 			clock      : in  std_logic;
 			reset      : in  std_logic;
 			timer_mode : in  unsigned(1 downto 0);
-			prescaler  : in  unsigned(15 downto 0);
-			compare    : in  unsigned(31 downto 0);
+			prescaler  : in  unsigned(prescaler_size - 1 downto 0);
+			compare    : in  unsigned(compare_size - 1 downto 0);
 			output     : out std_logic;
 			inv_output : out std_logic
 		);
@@ -23,8 +30,8 @@ architecture stimulus of testbench_timer_mode_00 is
 	signal clock      : std_logic;
 	signal reset      : std_logic;
 	signal timer_mode : unsigned(1 downto 0);
-	signal prescaler  : unsigned(15 downto 0);
-	signal compare    : unsigned(31 downto 0);
+	signal prescaler  : unsigned(prescaler_size_for_test - 1 downto 0);
+	signal compare    : unsigned(compare_size_for_test - 1 downto 0);
 	signal output     : std_logic;
 	signal inv_output : std_logic;
 
@@ -49,34 +56,34 @@ begin
 		clock <= '1';
 		wait for clock_period;
 	end process;
-	
-	test: process
+
+	test : process
 	begin
 		-- reset:
-		reset <= '1';
-		prescaler <= (others => '0');
+		reset      <= '1';
+		prescaler  <= (others => '0');
 		timer_mode <= (others => '0');
-		compare <= (others => '0');
-		wait for 1*clock_period;
-		
+		compare    <= (others => '0');
+		wait for 1 * clock_period;
+
 		-- configure to mode 00:
 		timer_mode <= "00";
-		prescaler <= x"0002";
-		compare <= x"00000003";
-		wait for 1*clock_period;
-		
+		prescaler  <= x"0001";
+		compare    <= x"A";
+		wait for 1 * clock_period;
+
 		-- run timer:
 		reset <= '0';
-		wait for 10*clock_period;
-		
+		wait for 100 * clock_period;
+
 		-- reset timer:
 		reset <= '1';
-		wait for 1*clock_period;
+		wait for 1 * clock_period;
 
 		-- run timer again:
 		reset <= '0';
-		wait for 10*clock_period;
-		
+		wait for 10 * clock_period;
+
 		wait;
 	end process;
 

--- a/peripherals/timer/tb_timer_mode_02.do
+++ b/peripherals/timer/tb_timer_mode_02.do
@@ -2,10 +2,10 @@
 vlib work
 
 # Compila projeto: todos os aquivo. Ordem é importante
-vcom Timer.vhd tb_timer_mode_03.vhd
+vcom Timer.vhd tb_timer_mode_02.vhd
 
 # Simula (work é o diretorio, testbench é o nome da entity)
-vsim -t ns work.testbench_timer_mode_03
+vsim -t ns work.testbench_timer_mode_02
 
 # Mosta forma de onda
 view wave
@@ -30,4 +30,4 @@ add wave -radix binary -label counter_direction /dut/internal_counter_direction
 run 2400ns
 
 wave zoomfull
-write wave testbench_timer_mode_03_wave.ps
+write wave testbench_timer_mode_02_wave.ps

--- a/peripherals/timer/tb_timer_mode_02.vhd
+++ b/peripherals/timer/tb_timer_mode_02.vhd
@@ -3,11 +3,11 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 -------------------------------------
-entity testbench_timer_mode_03 is
-end entity testbench_timer_mode_03;
+entity testbench_timer_mode_02 is
+end entity testbench_timer_mode_02;
 ------------------------------
 
-architecture stimulus of testbench_timer_mode_03 is
+architecture stimulus of testbench_timer_mode_02 is
 
 	constant prescaler_size_for_test : integer := 16;
 	constant compare_size_for_test   : integer := 4;

--- a/peripherals/timer/tb_timer_mode_03.do
+++ b/peripherals/timer/tb_timer_mode_03.do
@@ -2,10 +2,10 @@
 vlib work
 
 # Compila projeto: todos os aquivo. Ordem é importante
-vcom Timer.vhd tb_timer_mode_01.vhd
+vcom Timer.vhd tb_timer_mode_03.vhd
 
 # Simula (work é o diretorio, testbench é o nome da entity)
-vsim -t ns work.testbench_timer_mode_01
+vsim -t ns work.testbench_timer_mode_03
 
 # Mosta forma de onda
 view wave
@@ -30,4 +30,4 @@ add wave -radix binary -label counter_direction /dut/internal_counter_direction
 run 2400ns
 
 wave zoomfull
-write wave testbench_timer_mode_01_wave.ps
+write wave testbench_timer_mode_03_wave.ps

--- a/peripherals/timer/tb_timer_mode_03.vhd
+++ b/peripherals/timer/tb_timer_mode_03.vhd
@@ -3,11 +3,11 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 -------------------------------------
-entity testbench_timer_mode_01 is
-end entity testbench_timer_mode_01;
+entity testbench_timer_mode_03 is
+end entity testbench_timer_mode_03;
 ------------------------------
 
-architecture stimulus of testbench_timer_mode_01 is
+architecture stimulus of testbench_timer_mode_03 is
 
 	constant prescaler_size_for_test : integer := 16;
 	constant compare_size_for_test   : integer := 4;
@@ -66,8 +66,8 @@ begin
 		compare    <= (others => '0');
 		wait for 1 * clock_period;
 
-		-- configure to mode 01:
-		timer_mode <= "01";
+		-- configure to mode 03:
+		timer_mode <= "10";
 		prescaler  <= x"0001";
 		compare    <= x"A";
 		wait for 1 * clock_period;


### PR DESCRIPTION
solving #3 :

Tive que adicionar uns generics para que fosse possível simular com um contador menor, pois não seria viável simular um contador de 32 bits.

O funcionamento desse modo 03 é bastante limitado se a gente tiver somente 1 comparador, resultando em um sinal retangular com a metade da frequência do modo 02, mas ele fica simétrico e centralizado na metade do período. 

Quando implementarmos os 6 comparadores poderemos sincronizar e defasar corretamente um pwm trifásico, por exemplo.