### PR TITLE
More comparators and channels

### DIFF
--- a/peripherals/timer/Timer.vhd
+++ b/peripherals/timer/Timer.vhd
@@ -5,30 +5,35 @@ use ieee.numeric_std.all;
 entity Timer is
 	generic(
 		prescaler_size : integer := 16;
-		compare_size : integer := 32 
-		);
+		compare_size   : integer := 32
+	);
 	port(
 		clock      : in  std_logic;
 		reset      : in  std_logic;
 		timer_mode : in  unsigned(1 downto 0);
-		prescaler  : in  unsigned(prescaler_size-1 downto 0);
-		compare    : in  unsigned(compare_size-1 downto 0);
-		output     : out std_logic;
-		inv_output : out std_logic
+		prescaler  : in  unsigned(prescaler_size - 1 downto 0);
+		compare_0A    : in  unsigned(compare_size - 1 downto 0);
+		compare_0B    : in  unsigned(compare_size - 1 downto 0);
+		compare_1A    : in  unsigned(compare_size - 1 downto 0);
+		compare_1B    : in  unsigned(compare_size - 1 downto 0);
+		compare_2A    : in  unsigned(compare_size - 1 downto 0);
+		compare_2B    : in  unsigned(compare_size - 1 downto 0);
+		output_A     : out std_logic_vector(2 downto 0);
+		output_B : out std_logic_vector(2 downto 0)
 	);
 end entity Timer;
 
 architecture RTL of Timer is
-	constant counter_max	: unsigned(compare_size-1 downto 0) := (others => '1');
-	signal counter        : unsigned(compare_size-1 downto 0) := (others => '0');
-	signal internal_clock : std_logic             := '1';
-	signal internal_counter_direction : std_logic             := '0';
---	type counter_direction_t is (Up, Down);
+	constant counter_max              : unsigned(compare_size - 1 downto 0) := (others => '1');
+	signal counter                    : unsigned(compare_size - 1 downto 0) := (others => '0');
+	signal internal_clock             : std_logic                           := '1';
+	signal internal_counter_direction : std_logic                           := '0';
+	--	type counter_direction_t is (Up, Down);
 
 begin
 
 	p1 : process(clock) is              -- @suppress "Incomplete sensitivity list. Missing signals: prescaler, internal_clock"
-		variable temp_counter : unsigned(prescaler_size-1 downto 0) := (others => '0'); -- 17 bits devido ao prescaler ser multiplicado por 2.
+		variable temp_counter : unsigned(prescaler_size - 1 downto 0) := (others => '0'); -- 17 bits devido ao prescaler ser multiplicado por 2.
 	begin
 		if rising_edge(clock) OR falling_edge(clock) then
 			temp_counter := temp_counter + 1;
@@ -40,24 +45,38 @@ begin
 	end process p1;
 
 	p2 : process(internal_clock) is
-		variable internal_output   : std_logic           := '0';
+		variable internal_output   : std_logic_vector(2 downto 0) := (others => '0');
 		variable counter_direction : std_logic := '0';
 	begin
 		if rising_edge(internal_clock) then
 
 			if reset = '1' then
-				internal_output := '0';
-				counter         <= (others => '0');
+				internal_output   := (others => '0');
+				counter           <= (others => '0');
 				counter_direction := '0';
-				
+
 			else
 				case timer_mode is
 					when "00" =>        -- one shot mode
 
-						if counter >= compare - 1 then
-							internal_output := '1';
+						if counter >= compare_0A - 1 then
+							internal_output(0) := '1';
 						else
-							internal_output := '0';
+							internal_output(0) := '0';
+							counter         <= counter + 1;
+						end if;
+						
+						if counter >= compare_1A - 1 then
+							internal_output(1) := '1';
+						else
+							internal_output(1) := '0';
+							counter         <= counter + 1;
+						end if;
+						
+						if counter >= compare_2A - 1 then
+							internal_output(2) := '1';
+						else
+							internal_output(2) := '0';
 							counter         <= counter + 1;
 						end if;
 
@@ -71,51 +90,92 @@ begin
 							counter <= counter + 1;
 						end if;
 
-						if counter >= compare - 1 then
-							internal_output := '1';
+						if (counter >= compare_0A - 1) and (counter < compare_0B - 1) then
+							internal_output(0) := '1';
 						else
-							internal_output := '0';
+							internal_output(0) := '0';
+						end if;
+						
+						if (counter >= compare_1A - 1) and (counter < compare_1B - 1) then
+							internal_output(1) := '1';
+						else
+							internal_output(1) := '0';
+						end if;
+						
+						if (counter >= compare_2A - 1) and (counter < compare_2B - 1) then
+							internal_output(2) := '1';
+						else
+							internal_output(2) := '0';
 						end if;
 
 					when "10" =>        -- clear on compare mode, counter is a centered triangle wave
 
 						-- the counter change its direction (up or down) when it reaches its maximum possible value
-						-- the output has a rectangular waveform centered to the top value
+						-- the output has a rectangular waveform centered to the top value, active when between A and B comparators. 
 						if counter_direction = '0' then
 							if counter >= counter_max then
 								counter_direction := '1';
+								counter <= counter - 1;
 							else
 								counter <= counter + 1;
 							end if;
-
-							if counter >= compare - 1 then
-								internal_output := '1';
+							
+							if counter >= compare_0A - 1 then
+								internal_output(0) := '1';
 							else
-								internal_output := '0';
+								internal_output(0) := '0';
 							end if;
-
+							
+							if counter >= compare_1A - 1 then
+								internal_output(1) := '1';
+							else
+								internal_output(1) := '0';
+							end if;
+							
+							if counter >= compare_2A - 1 then
+								internal_output(2) := '1';
+							else
+								internal_output(2) := '0';
+							end if;
+							
 						else
 							if counter <= 0 then
-								counter_direction := '1';
+								counter_direction := '0';
+								counter <= counter + 1;
 							else
 								counter <= counter - 1;
 							end if;
-
-							if counter > compare - 1 then
-								internal_output := '1';
+							
+							if counter > compare_0B - 1 then
+								internal_output(0) := '1';
 							else
-								internal_output := '0';
+								internal_output(0) := '0';
 							end if;
+							
+							if counter > compare_1B - 1 then
+								internal_output(1) := '1';
+							else
+								internal_output(1) := '0';
+							end if;
+							
+							if counter > compare_2B - 1 then
+								internal_output(2) := '1';
+							else
+								internal_output(2) := '0';
+							end if;
+							
 						end if;
+
 						internal_counter_direction <= counter_direction;
 
 					when others =>      -- none / error
-						internal_output := '0';
+						internal_output := (others => '0');
+
 				end case;
 			end if;
 
-			output     <= internal_output;
-			inv_output <= not (internal_output);
+			output_A     <= internal_output;
+			output_B <= not (internal_output);
 
 		end if;
 

--- a/peripherals/timer/tb_timer_mode_00.do
+++ b/peripherals/timer/tb_timer_mode_00.do
@@ -23,12 +23,12 @@ add wave -radix unsigned -label compare_1A /compare_1A
 add wave -radix unsigned -label compare_1B /compare_1B
 add wave -radix unsigned -label compare_2A /compare_2A
 add wave -radix unsigned -label compare_2B /compare_2B
-add wave -radix binary -label output_A /output_A(0)
-add wave -radix binary -label output_B /output_B(0)
-add wave -radix binary -label output_A /output_A(1)
-add wave -radix binary -label output_B /output_B(1)
-add wave -radix binary -label output_A /output_A(2)
-add wave -radix binary -label output_B /output_B(2)
+add wave -radix binary -label output_0A /output_A(0)
+add wave -radix binary -label output_0B /output_B(0)
+add wave -radix binary -label output_1A /output_A(1)
+add wave -radix binary -label output_1B /output_B(1)
+add wave -radix binary -label output_2A /output_A(2)
+add wave -radix binary -label output_2B /output_B(2)
 
 # Mostra sinais internos do processo
 add wave -radix unsigned -label counter /dut/counter

--- a/peripherals/timer/tb_timer_mode_00.do
+++ b/peripherals/timer/tb_timer_mode_00.do
@@ -17,9 +17,18 @@ add wave -radix binary -label clock /clock
 add wave -radix binary -label reset /reset
 add wave -radix binary -label mode /timer_mode
 add wave -radix unsigned -label prescaler /prescaler
-add wave -radix unsigned -label compare /compare
-add wave -radix binary -label output /output
-add wave -radix binary -label inv_output /inv_output
+add wave -radix unsigned -label compare_0A /compare_0A
+add wave -radix unsigned -label compare_0B /compare_0B
+add wave -radix unsigned -label compare_1A /compare_1A
+add wave -radix unsigned -label compare_1B /compare_1B
+add wave -radix unsigned -label compare_2A /compare_2A
+add wave -radix unsigned -label compare_2B /compare_2B
+add wave -radix binary -label output_A /output_A(0)
+add wave -radix binary -label output_B /output_B(0)
+add wave -radix binary -label output_A /output_A(1)
+add wave -radix binary -label output_B /output_B(1)
+add wave -radix binary -label output_A /output_A(2)
+add wave -radix binary -label output_B /output_B(2)
 
 # Mostra sinais internos do processo
 add wave -radix unsigned -label counter /dut/counter

--- a/peripherals/timer/tb_timer_mode_00.vhd
+++ b/peripherals/timer/tb_timer_mode_00.vhd
@@ -22,18 +22,28 @@ architecture stimulus of testbench_timer_mode_00 is
 			reset      : in  std_logic;
 			timer_mode : in  unsigned(1 downto 0);
 			prescaler  : in  unsigned(prescaler_size - 1 downto 0);
-			compare    : in  unsigned(compare_size - 1 downto 0);
-			output     : out std_logic;
-			inv_output : out std_logic
+			compare_0A : in  unsigned(compare_size - 1 downto 0);
+			compare_0B : in  unsigned(compare_size - 1 downto 0);
+			compare_1A : in  unsigned(compare_size - 1 downto 0);
+			compare_1B : in  unsigned(compare_size - 1 downto 0);
+			compare_2A : in  unsigned(compare_size - 1 downto 0);
+			compare_2B : in  unsigned(compare_size - 1 downto 0);
+			output_A   : out std_logic_vector(2 downto 0);
+			output_B   : out std_logic_vector(2 downto 0)
 		);
 	end component Timer;
 	signal clock      : std_logic;
 	signal reset      : std_logic;
 	signal timer_mode : unsigned(1 downto 0);
 	signal prescaler  : unsigned(prescaler_size_for_test - 1 downto 0);
-	signal compare    : unsigned(compare_size_for_test - 1 downto 0);
-	signal output     : std_logic;
-	signal inv_output : std_logic;
+	signal compare_0A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_0B : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_1A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_1B : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_2A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_2B : unsigned(compare_size_for_test - 1 downto 0);
+	signal output_A   : std_logic_vector(2 downto 0);
+	signal output_B   : std_logic_vector(2 downto 0);
 
 	constant clock_period : time := 20 ns;
 
@@ -44,9 +54,14 @@ begin
 			reset      => reset,
 			timer_mode => timer_mode,
 			prescaler  => prescaler,
-			compare    => compare,
-			output     => output,
-			inv_output => inv_output
+			compare_0A => compare_0A,
+			compare_0B => compare_0B,
+			compare_1A => compare_1A,
+			compare_1B => compare_1B,
+			compare_2A => compare_2A,
+			compare_2B => compare_2B,
+			output_A   => output_A,
+			output_B   => output_B
 		);
 
 	test_clock : process
@@ -63,13 +78,23 @@ begin
 		reset      <= '1';
 		prescaler  <= (others => '0');
 		timer_mode <= (others => '0');
-		compare    <= (others => '0');
+		compare_0A <= (others => '0');
+		compare_0B <= (others => '0');
+		compare_1A <= (others => '0');
+		compare_1B <= (others => '0');
+		compare_2A <= (others => '0');
+		compare_2B <= (others => '0');
 		wait for 1 * clock_period;
 
 		-- configure to mode 00:
 		timer_mode <= "00";
 		prescaler  <= x"0001";
-		compare    <= x"A";
+		compare_0A <= x"4";
+		compare_0B <= x"5";
+		compare_1A <= x"6";
+		compare_1B <= x"7";
+		compare_2A <= x"8";
+		compare_2B <= x"9";
 		wait for 1 * clock_period;
 
 		-- run timer:

--- a/peripherals/timer/tb_timer_mode_01.do
+++ b/peripherals/timer/tb_timer_mode_01.do
@@ -17,9 +17,18 @@ add wave -radix binary -label clock /clock
 add wave -radix binary -label reset /reset
 add wave -radix binary -label mode /timer_mode
 add wave -radix unsigned -label prescaler /prescaler
-add wave -radix unsigned -label compare /compare
-add wave -radix binary -label output /output
-add wave -radix binary -label inv_output /inv_output
+add wave -radix unsigned -label compare_0A /compare_0A
+add wave -radix unsigned -label compare_0B /compare_0B
+add wave -radix unsigned -label compare_1A /compare_1A
+add wave -radix unsigned -label compare_1B /compare_1B
+add wave -radix unsigned -label compare_2A /compare_2A
+add wave -radix unsigned -label compare_2B /compare_2B
+add wave -radix binary -label output_A /output_A(0)
+add wave -radix binary -label output_B /output_B(0)
+add wave -radix binary -label output_A /output_A(1)
+add wave -radix binary -label output_B /output_B(1)
+add wave -radix binary -label output_A /output_A(2)
+add wave -radix binary -label output_B /output_B(2)
 
 # Mostra sinais internos do processo
 add wave -radix unsigned -label counter /dut/counter

--- a/peripherals/timer/tb_timer_mode_01.vhd
+++ b/peripherals/timer/tb_timer_mode_01.vhd
@@ -22,18 +22,28 @@ architecture stimulus of testbench_timer_mode_01 is
 			reset      : in  std_logic;
 			timer_mode : in  unsigned(1 downto 0);
 			prescaler  : in  unsigned(prescaler_size - 1 downto 0);
-			compare    : in  unsigned(compare_size - 1 downto 0);
-			output     : out std_logic;
-			inv_output : out std_logic
+			compare_0A : in  unsigned(compare_size - 1 downto 0);
+			compare_0B : in  unsigned(compare_size - 1 downto 0);
+			compare_1A : in  unsigned(compare_size - 1 downto 0);
+			compare_1B : in  unsigned(compare_size - 1 downto 0);
+			compare_2A : in  unsigned(compare_size - 1 downto 0);
+			compare_2B : in  unsigned(compare_size - 1 downto 0);
+			output_A   : out std_logic_vector(2 downto 0);
+			output_B   : out std_logic_vector(2 downto 0)
 		);
 	end component Timer;
 	signal clock      : std_logic;
 	signal reset      : std_logic;
 	signal timer_mode : unsigned(1 downto 0);
 	signal prescaler  : unsigned(prescaler_size_for_test - 1 downto 0);
-	signal compare    : unsigned(compare_size_for_test - 1 downto 0);
-	signal output     : std_logic;
-	signal inv_output : std_logic;
+	signal compare_0A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_0B : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_1A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_1B : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_2A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_2B : unsigned(compare_size_for_test - 1 downto 0);
+	signal output_A   : std_logic_vector(2 downto 0);
+	signal output_B   : std_logic_vector(2 downto 0);
 
 	constant clock_period : time := 20 ns;
 
@@ -44,9 +54,14 @@ begin
 			reset      => reset,
 			timer_mode => timer_mode,
 			prescaler  => prescaler,
-			compare    => compare,
-			output     => output,
-			inv_output => inv_output
+			compare_0A => compare_0A,
+			compare_0B => compare_0B,
+			compare_1A => compare_1A,
+			compare_1B => compare_1B,
+			compare_2A => compare_2A,
+			compare_2B => compare_2B,
+			output_A   => output_A,
+			output_B   => output_B
 		);
 
 	test_clock : process
@@ -63,13 +78,23 @@ begin
 		reset      <= '1';
 		prescaler  <= (others => '0');
 		timer_mode <= (others => '0');
-		compare    <= (others => '0');
+		compare_0A <= (others => '0');
+		compare_0B <= (others => '0');
+		compare_1A <= (others => '0');
+		compare_1B <= (others => '0');
+		compare_2A <= (others => '0');
+		compare_2B <= (others => '0');
 		wait for 1 * clock_period;
 
 		-- configure to mode 01:
 		timer_mode <= "01";
 		prescaler  <= x"0001";
-		compare    <= x"A";
+		compare_0A <= x"1";
+		compare_0B <= x"5";
+		compare_1A <= x"6";
+		compare_1B <= x"A";
+		compare_2A <= x"B";
+		compare_2B <= x"F";
 		wait for 1 * clock_period;
 
 		-- run timer:

--- a/peripherals/timer/tb_timer_mode_02.do
+++ b/peripherals/timer/tb_timer_mode_02.do
@@ -23,12 +23,12 @@ add wave -radix unsigned -label compare_1A /compare_1A
 add wave -radix unsigned -label compare_1B /compare_1B
 add wave -radix unsigned -label compare_2A /compare_2A
 add wave -radix unsigned -label compare_2B /compare_2B
-add wave -radix binary -label output_A /output_A(0)
-add wave -radix binary -label output_B /output_B(0)
-add wave -radix binary -label output_A /output_A(1)
-add wave -radix binary -label output_B /output_B(1)
-add wave -radix binary -label output_A /output_A(2)
-add wave -radix binary -label output_B /output_B(2)
+add wave -radix binary -label output_0A /output_A(0)
+add wave -radix binary -label output_0B /output_B(0)
+add wave -radix binary -label output_1A /output_A(1)
+add wave -radix binary -label output_1B /output_B(1)
+add wave -radix binary -label output_2A /output_A(2)
+add wave -radix binary -label output_2B /output_B(2)
 
 # Mostra sinais internos do processo
 add wave -radix unsigned -label counter /dut/counter

--- a/peripherals/timer/tb_timer_mode_02.do
+++ b/peripherals/timer/tb_timer_mode_02.do
@@ -17,9 +17,18 @@ add wave -radix binary -label clock /clock
 add wave -radix binary -label reset /reset
 add wave -radix binary -label mode /timer_mode
 add wave -radix unsigned -label prescaler /prescaler
-add wave -radix unsigned -label compare /compare
-add wave -radix binary -label output /output
-add wave -radix binary -label inv_output /inv_output
+add wave -radix unsigned -label compare_0A /compare_0A
+add wave -radix unsigned -label compare_0B /compare_0B
+add wave -radix unsigned -label compare_1A /compare_1A
+add wave -radix unsigned -label compare_1B /compare_1B
+add wave -radix unsigned -label compare_2A /compare_2A
+add wave -radix unsigned -label compare_2B /compare_2B
+add wave -radix binary -label output_A /output_A(0)
+add wave -radix binary -label output_B /output_B(0)
+add wave -radix binary -label output_A /output_A(1)
+add wave -radix binary -label output_B /output_B(1)
+add wave -radix binary -label output_A /output_A(2)
+add wave -radix binary -label output_B /output_B(2)
 
 # Mostra sinais internos do processo
 add wave -radix unsigned -label counter /dut/counter
@@ -27,7 +36,7 @@ add wave -radix binary -label internal_clock /dut/internal_clock
 add wave -radix binary -label counter_direction /dut/internal_counter_direction
 
 # Simula
-run 2400ns
+run 4800ns
 
 wave zoomfull
 write wave testbench_timer_mode_02_wave.ps

--- a/peripherals/timer/tb_timer_mode_02.vhd
+++ b/peripherals/timer/tb_timer_mode_02.vhd
@@ -22,18 +22,28 @@ architecture stimulus of testbench_timer_mode_02 is
 			reset      : in  std_logic;
 			timer_mode : in  unsigned(1 downto 0);
 			prescaler  : in  unsigned(prescaler_size - 1 downto 0);
-			compare    : in  unsigned(compare_size - 1 downto 0);
-			output     : out std_logic;
-			inv_output : out std_logic
+			compare_0A : in  unsigned(compare_size - 1 downto 0);
+			compare_0B : in  unsigned(compare_size - 1 downto 0);
+			compare_1A : in  unsigned(compare_size - 1 downto 0);
+			compare_1B : in  unsigned(compare_size - 1 downto 0);
+			compare_2A : in  unsigned(compare_size - 1 downto 0);
+			compare_2B : in  unsigned(compare_size - 1 downto 0);
+			output_A     : out std_logic_vector(2 downto 0);
+			output_B : out std_logic_vector(2 downto 0)
 		);
 	end component Timer;
 	signal clock      : std_logic;
 	signal reset      : std_logic;
 	signal timer_mode : unsigned(1 downto 0);
 	signal prescaler  : unsigned(prescaler_size_for_test - 1 downto 0);
-	signal compare    : unsigned(compare_size_for_test - 1 downto 0);
-	signal output     : std_logic;
-	signal inv_output : std_logic;
+	signal compare_0A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_0B : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_1A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_1B : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_2A : unsigned(compare_size_for_test - 1 downto 0);
+	signal compare_2B : unsigned(compare_size_for_test - 1 downto 0);
+	signal output_A     : std_logic_vector(2 downto 0);
+	signal output_B : std_logic_vector(2 downto 0);
 
 	constant clock_period : time := 20 ns;
 
@@ -44,9 +54,14 @@ begin
 			reset      => reset,
 			timer_mode => timer_mode,
 			prescaler  => prescaler,
-			compare    => compare,
-			output     => output,
-			inv_output => inv_output
+			compare_0A => compare_0A,
+			compare_0B => compare_0B,
+			compare_1A => compare_1A,
+			compare_1B => compare_1B,
+			compare_2A => compare_2A,
+			compare_2B => compare_2B,
+			output_A     => output_A,
+			output_B => output_B
 		);
 
 	test_clock : process
@@ -63,18 +78,28 @@ begin
 		reset      <= '1';
 		prescaler  <= (others => '0');
 		timer_mode <= (others => '0');
-		compare    <= (others => '0');
+		compare_0A <= (others => '0');
+		compare_0B <= (others => '0');
+		compare_1A <= (others => '0');
+		compare_1B <= (others => '0');
+		compare_2A <= (others => '0');
+		compare_2B <= (others => '0');
 		wait for 1 * clock_period;
 
 		-- configure to mode 03:
 		timer_mode <= "10";
 		prescaler  <= x"0001";
-		compare    <= x"A";
+		compare_0A <= x"A";
+		compare_0B <= x"A";
+		compare_1A <= x"C";
+		compare_1B <= x"C";
+		compare_2A <= x"E";
+		compare_2B <= x"E";
 		wait for 1 * clock_period;
 
 		-- run timer:
 		reset <= '0';
-		wait for 100 * clock_period;
+		wait for 300 * clock_period;
 
 		-- reset timer:
 		reset <= '1';

--- a/peripherals/timer/tb_timer_mode_03.do
+++ b/peripherals/timer/tb_timer_mode_03.do
@@ -2,10 +2,10 @@
 vlib work
 
 # Compila projeto: todos os aquivo. Ordem é importante
-vcom Timer.vhd tb_timer_mode_01.vhd
+vcom Timer.vhd tb_timer_mode_03.vhd
 
 # Simula (work é o diretorio, testbench é o nome da entity)
-vsim -t ns work.testbench_timer_mode_01
+vsim -t ns work.testbench_timer_mode_03
 
 # Mosta forma de onda
 view wave
@@ -39,4 +39,4 @@ add wave -radix binary -label counter_direction /dut/internal_counter_direction
 run 2400ns
 
 wave zoomfull
-write wave testbench_timer_mode_01_wave.ps
+write wave testbench_timer_mode_03_wave.ps

--- a/peripherals/timer/tb_timer_mode_03.vhd
+++ b/peripherals/timer/tb_timer_mode_03.vhd
@@ -3,11 +3,11 @@ use ieee.std_logic_1164.all;
 use ieee.numeric_std.all;
 
 -------------------------------------
-entity testbench_timer_mode_02 is
-end entity testbench_timer_mode_02;
+entity testbench_timer_mode_03 is
+end entity testbench_timer_mode_03;
 ------------------------------
 
-architecture stimulus of testbench_timer_mode_02 is
+architecture stimulus of testbench_timer_mode_03 is
 
 	constant prescaler_size_for_test : integer := 16;
 	constant compare_size_for_test   : integer := 4;
@@ -87,19 +87,19 @@ begin
 		wait for 1 * clock_period;
 
 		-- configure to mode 03:
-		timer_mode <= "10";
+		timer_mode <= "11";
 		prescaler  <= x"0001";
-		compare_0A <= x"B";
-		compare_0B <= x"A";
-		compare_1A <= x"D";
-		compare_1B <= x"C";
-		compare_2A <= x"F";
-		compare_2B <= x"E";
+		compare_0A <= x"2";
+		compare_0B <= x"4";
+		compare_1A <= x"6";
+		compare_1B <= x"8";
+		compare_2A <= x"A";
+		compare_2B <= x"C";
 		wait for 1 * clock_period;
 
 		-- run timer:
 		reset <= '0';
-		wait for 300 * clock_period;
+		wait for 100 * clock_period;
 
 		-- reset timer:
 		reset <= '1';


### PR DESCRIPTION
It solves #18 and also implement a several enhancements:
- To be able to perform triphase inverter PWM, 3 independent channels are implemented.
- Implements 2 comparators per channel named A and B, and its behavior depends on the selected mode.
- Implements 2 outputs per channel named A and B, and its behavior depends on the selected mode.
- Implements a fourth mode: very similar to mode 01, but A and B are independent, while I changed the mode 01 to have its output active when the counter is between the value of the two comparators.
Note that deadband / deadtime is possible in mode 03 because output A and B are actually independent of each others value (see the simulation).